### PR TITLE
Fix for table view headers stopping at the wrong content offset. Closes ...

### DIFF
--- a/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.m
+++ b/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.m
@@ -159,4 +159,11 @@
     }
 }
 
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView
+{
+    CGPoint contentOffset = scrollView.contentOffset;
+    scrollView.contentInset = UIEdgeInsetsMake(CGRectGetMaxY(self.flexibleHeightBar.frame), scrollView.contentInset.left, scrollView.contentInset.bottom, scrollView.contentInset.right);
+    scrollView.contentOffset = contentOffset;
+}
+
 @end

--- a/BLKFlexibleHeightBar/FacebookStyleBarBehaviorDefiner.m
+++ b/BLKFlexibleHeightBar/FacebookStyleBarBehaviorDefiner.m
@@ -151,6 +151,8 @@
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
+    [super scrollViewDidScroll: scrollView];
+    
     if(!self.isCurrentlySnapping)
     {
         CGFloat deltaYOffset = scrollView.contentOffset.y - self.previousYOffset;

--- a/BLKFlexibleHeightBar/SquareCashStyleBehaviorDefiner.m
+++ b/BLKFlexibleHeightBar/SquareCashStyleBehaviorDefiner.m
@@ -28,6 +28,8 @@
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
+    [super scrollViewDidScroll: scrollView];
+    
     if(!self.isCurrentlySnapping)
     {
         CGFloat progress = (scrollView.contentOffset.y+scrollView.contentInset.top) / (self.flexibleHeightBar.maximumBarHeight-self.flexibleHeightBar.minimumBarHeight);


### PR DESCRIPTION
...#14.

The trick is preserving the scroll view's content offset when changing its content inset. Tested on iOS 7 and 8, iPhone 6+ and iPad.
