### PR TITLE
add customizing snapping animate duration property

### DIFF
--- a/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.h
+++ b/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.h
@@ -45,6 +45,11 @@
 @property (nonatomic, getter=isCurrentlySnapping) BOOL currentlySnapping;
 
 /**
+ *  Determines the animation duration while snapping
+ */
+@property (nonatomic, assign) CGFloat snappingAnimateDuration;
+
+/**
  Determines whether the bar can stretch to larger sizes than it's `maximumBarHeight`. Default value is NO.
  */
 @property (nonatomic, getter=isElasticMaximumHeightAtTop) BOOL elasticMaximumHeightAtTop;

--- a/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.m
+++ b/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.m
@@ -39,6 +39,7 @@
         _snappingEnabled = YES;
         _currentlySnapping = NO;
         _elasticMaximumHeightAtTop = NO;
+        _snappingAnimateDuration = 0.15;
     }
     
     return self;
@@ -126,7 +127,7 @@
         
         if(snapPosition != MAXFLOAT)
         {
-            [UIView animateWithDuration:0.15 animations:^{
+            [UIView animateWithDuration:self.snappingAnimateDuration animations:^{
                 
                 [self snapToProgress:snapPosition scrollView:scrollView];
                 


### PR DESCRIPTION
add customizing snapping animate duration property, so whoever uses definers can define the snapping animate duration. default is 0.15 secs

```Objective-C
 *  Determines the animation duration while snapping
 */
@property (nonatomic, assign) CGFloat snappingAnimateDuration;

/**
```