### PR TITLE
Fix for tableView headers

### DIFF
--- a/BLKFlexibleHeightBar Demo/FacebookStyleBar.m
+++ b/BLKFlexibleHeightBar Demo/FacebookStyleBar.m
@@ -20,6 +20,16 @@
     return self;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame andTableView:(UITableView *)tableView
+{
+    if(self = [super initWithFrame:frame andTableView:tableView])
+    {
+        [self configureBar];
+    }
+    
+    return self;
+}
+
 - (void)configureBar
 {
     // Configure bar appearence

--- a/BLKFlexibleHeightBar Demo/FacebookStyleViewController.m
+++ b/BLKFlexibleHeightBar Demo/FacebookStyleViewController.m
@@ -27,7 +27,7 @@
     [self setNeedsStatusBarAppearanceUpdate];
     
     // Setup the bar
-    self.myCustomBar = [[FacebookStyleBar alloc] initWithFrame:CGRectMake(0.0, 0.0, CGRectGetWidth(self.view.frame), 100.0)];
+    self.myCustomBar = [[FacebookStyleBar alloc] initWithFrame:CGRectMake(0.0, 0.0, CGRectGetWidth(self.view.frame), 100.0) andTableView:self.tableView];
     
     FacebookStyleBarBehaviorDefiner *behaviorDefiner = [[FacebookStyleBarBehaviorDefiner alloc] init];
     [behaviorDefiner addSnappingPositionProgress:0.0 forProgressRangeStart:0.0 end:40.0/(105.0-20.0)];
@@ -86,6 +86,14 @@
 
 
 # pragma mark - UITableViewDataSource methods
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
+{
+    return @"This view will be out of place";
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 2;
+}
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {

--- a/BLKFlexibleHeightBar Demo/SquareCashStyleBar.m
+++ b/BLKFlexibleHeightBar Demo/SquareCashStyleBar.m
@@ -20,6 +20,16 @@
     return self;
 }
 
+- (instancetype)initWithFrame:(CGRect)frame andTableView:(UITableView *)tableView
+{
+    if(self = [super initWithFrame:frame andTableView:tableView])
+    {
+        [self configureBar];
+    }
+    
+    return self;
+}
+
 - (void)configureBar
 {
     // Configure bar appearence

--- a/BLKFlexibleHeightBar Demo/SquareCashStyleViewController.m
+++ b/BLKFlexibleHeightBar Demo/SquareCashStyleViewController.m
@@ -29,7 +29,7 @@
     [self setNeedsStatusBarAppearanceUpdate];
     
     // Setup the bar
-    self.myCustomBar = [[SquareCashStyleBar alloc] initWithFrame:CGRectMake(0.0, 0.0, CGRectGetWidth(self.view.frame), 100.0)];
+    self.myCustomBar = [[SquareCashStyleBar alloc] initWithFrame:CGRectMake(0.0, 0.0, CGRectGetWidth(self.view.frame), 100.0) andTableView:self.tableView];
     
     SquareCashStyleBehaviorDefiner *behaviorDefiner = [[SquareCashStyleBehaviorDefiner alloc] init];
     [behaviorDefiner addSnappingPositionProgress:0.0 forProgressRangeStart:0.0 end:0.5];
@@ -76,6 +76,14 @@
 
 
 # pragma mark - UITableViewDataSource methods
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section
+{
+    return @"This view will be out of place";
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 2;
+}
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section
 {

--- a/BLKFlexibleHeightBar/BLKFlexibleHeightBar.h
+++ b/BLKFlexibleHeightBar/BLKFlexibleHeightBar.h
@@ -32,6 +32,14 @@
  */
 
 @interface BLKFlexibleHeightBar : UIView
+/**
+ *  Use this initializer when you are using a UITableView as your scrollView
+ *  It will adjust the contentInset of the table when bar height changes
+ *  This way, section headers (which are contentInset based) will scroll
+ *
+ *  @param tableView The tableView you are placing below the BLKFlexibleTableViewHeightBar
+ */
+- (instancetype)initWithFrame:(CGRect)frame andTableView:(UITableView *)tableView;
 
 /**
  The current progress, representing how much the bar has shrunk. progress == 0.0 puts the bar at its maximum height. progress == 1.0 puts the bar at its minimum height. The default value is 0.0.

--- a/BLKFlexibleHeightBar/BLKFlexibleHeightBar.m
+++ b/BLKFlexibleHeightBar/BLKFlexibleHeightBar.m
@@ -20,7 +20,7 @@
 #import "BLKFlexibleHeightBar.h"
 
 @interface BLKFlexibleHeightBar ()
-
+@property (nonatomic, weak) IBOutlet UITableView *tableView;
 @end
 
 @implementation BLKFlexibleHeightBar
@@ -47,6 +47,18 @@
     if(self = [super initWithFrame:frame])
     {
         [self commonInit];
+        _maximumBarHeight = CGRectGetMaxY(frame);
+    }
+    
+    return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame andTableView:(UITableView *)tableView
+{
+    if(self = [super initWithFrame:frame])
+    {
+        [self commonInit];
+        self.tableView = tableView;
         _maximumBarHeight = CGRectGetMaxY(frame);
     }
     
@@ -118,6 +130,16 @@
         }
         
     }];
+    
+    if (self.tableView) {
+        [self updateTableViewContentInset];
+    }
+}
+
+- (void)updateTableViewContentInset {
+    if (self.frame.size.height <= self.maximumBarHeight) {
+        self.tableView.contentInset = UIEdgeInsetsMake(self.frame.size.height + self.frame.origin.y, 0, 0, 0);
+    }
 }
 
 - (void)applyFloorLayoutAttributes:(BLKFlexibleHeightBarSubviewLayoutAttributes *)floorLayoutAttributes ceilingLayoutAttributes:(BLKFlexibleHeightBarSubviewLayoutAttributes *)ceilingLayoutAttributes toSubview:(UIView *)subview withFloorProgress:(CGFloat)floorProgress ceilingProgress:(CGFloat)ceilingProgress;

--- a/BLKFlexibleHeightBar/SquareCashStyleBehaviorDefiner.m
+++ b/BLKFlexibleHeightBar/SquareCashStyleBehaviorDefiner.m
@@ -30,7 +30,7 @@
 {
     if(!self.isCurrentlySnapping)
     {
-        CGFloat progress = (scrollView.contentOffset.y+scrollView.contentInset.top) / (self.flexibleHeightBar.maximumBarHeight-self.flexibleHeightBar.minimumBarHeight);
+        CGFloat progress = (scrollView.contentOffset.y + self.flexibleHeightBar.maximumBarHeight) / (self.flexibleHeightBar.maximumBarHeight-self.flexibleHeightBar.minimumBarHeight);
         self.flexibleHeightBar.progress = progress;
         [self.flexibleHeightBar setNeedsLayout];
     }


### PR DESCRIPTION
@bryankeller This solves the issues with the tableView headers in https://github.com/bryankeller/BLKFlexibleHeightBar/issues/8
and maybe in (didn't test it) https://github.com/bryankeller/BLKFlexibleHeightBar/issues/14

Section headers in UITableView are based on contentInset. If the bar shrinks, the tableView needs to have contentInset udpated in order to have the headers scroll smoothly.

I don't think there is a need to change the contentInset for all UIScrollView's (just for the ones that are UITableViews) so I created one initializer in the bar to pass the tableview. This way people can still use the regular initializer you created for UIScrollViews.

Finally, I had to change scrollViewDidScroll of SquareCashStyleBehaviorDefiner. It was doing a check based on the contentInset and since that changes now, it didn't work well. Now is based on the max bar height which works great.

Hope this helps!

Pablo 