### PR TITLE
Fix progress setting conflict

### DIFF
--- a/BLKFlexibleHeightBar/BLKFlexibleHeightBar.m
+++ b/BLKFlexibleHeightBar/BLKFlexibleHeightBar.m
@@ -81,11 +81,6 @@
     barFrame.size.height = [self interpolateFromValue:self.maximumBarHeight toValue:self.minimumBarHeight withProgress:self.progress];
     self.frame = barFrame;
     
-    if(self.behaviorDefiner && self.behaviorDefiner.isElasticMaximumHeightAtTop)
-    {
-        self.progress = fmax(self.progress, 0.0);
-    }
-    
     // Update subviews using the appropriate layout attributes for the current progress
     [self.subviews enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
         


### PR DESCRIPTION
Setting progress in `- (void)layoutSubviews` is conflith with `- (void)setProgress:(CGFloat)progress`.

Let's presume that `behaviorDefiner` instance has its `elasticMaximumHeightAtTop` set to YES and developer set progress to `-0.5`, then trigger layouting subviews. The settting in `- (void)layoutSubviews` will be setting `progress` again and set it to `0.0`.

The setting code in  `- (void)layoutSubviews` is useless and misleading.