### PR TITLE
Safari-style bar behavior definer + delegate for creating a delegate chain

### DIFF
--- a/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.h
+++ b/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.h
@@ -37,9 +37,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, weak) BLKFlexibleHeightBar *flexibleHeightBar;
 
 /**
- All scroll-related messages will be redirected to this delegate.
+ All unhandled messages will be redirected to this delegate.
  */
-@property (nonatomic, weak) id<UIScrollViewDelegate> delegate;
+@property (nonatomic, weak) id<NSObject> delegate;
 
 /**
  Determines whether snapping is enabled or not. Default value is YES.
@@ -101,21 +101,6 @@ NS_ASSUME_NONNULL_BEGIN
  Subclass implementations should call super's implementation.
  */
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView;
-
-/**
- A UIScrollViewDelegate methods implementations for redirecting to delegate object.
- Subclass implementations should call super's implementation.
- */
-- (void)scrollViewDidZoom:(UIScrollView *)scrollView;
-- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView;
-- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset;
-- (void)scrollViewWillBeginDecelerating:(UIScrollView *)scrollView;
-- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView;
-- (nullable UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView;
-- (void)scrollViewWillBeginZooming:(UIScrollView *)scrollView withView:(nullable UIView *)view;
-- (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(nullable UIView *)view atScale:(CGFloat)scale;
-- (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView;
-- (void)scrollViewDidScrollToTop:(UIScrollView *)scrollView;
 
 @end
 

--- a/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.h
+++ b/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.h
@@ -20,6 +20,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class BLKFlexibleHeightBar;
 
 /**
@@ -33,6 +35,11 @@
  The `BLKFlexibleHeightBar` instance corresponding with the behavior definer.
  */
 @property (nonatomic, readonly, weak) BLKFlexibleHeightBar *flexibleHeightBar;
+
+/**
+ All scroll-related messages will be redirected to this delegate.
+ */
+@property (nonatomic, weak) id<UIScrollViewDelegate> delegate;
 
 /**
  Determines whether snapping is enabled or not. Default value is YES.
@@ -95,4 +102,21 @@
  */
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView;
 
+/**
+ A UIScrollViewDelegate methods implementations for redirecting to delegate object.
+ Subclass implementations should call super's implementation.
+ */
+- (void)scrollViewDidZoom:(UIScrollView *)scrollView;
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView;
+- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset;
+- (void)scrollViewWillBeginDecelerating:(UIScrollView *)scrollView;
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView;
+- (nullable UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView;
+- (void)scrollViewWillBeginZooming:(UIScrollView *)scrollView withView:(nullable UIView *)view;
+- (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(nullable UIView *)view atScale:(CGFloat)scale;
+- (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView;
+- (void)scrollViewDidScrollToTop:(UIScrollView *)scrollView;
+
 @end
+
+NS_ASSUME_NONNULL_END

--- a/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.m
+++ b/BLKFlexibleHeightBar/BLKFlexibleHeightBarBehaviorDefiner.m
@@ -149,6 +149,11 @@
 - (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
 {
     [self snapWithScrollView:scrollView];
+    
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidEndDecelerating:)])
+    {
+        [self.delegate scrollViewDidEndDecelerating:scrollView];
+    }
 }
 
 - (void)scrollViewDidEndDragging:(UIScrollView *)scrollView willDecelerate:(BOOL)decelerate
@@ -157,11 +162,105 @@
     {
         [self snapWithScrollView:scrollView];
     }
+    
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidEndDragging:willDecelerate:)])
+    {
+        [self.delegate scrollViewDidEndDragging:scrollView willDecelerate:decelerate];
+    }
 }
 
 - (void)scrollViewDidScroll:(UIScrollView *)scrollView
 {
     scrollView.scrollIndicatorInsets =  UIEdgeInsetsMake(CGRectGetHeight(self.flexibleHeightBar.bounds), scrollView.scrollIndicatorInsets.left, scrollView.scrollIndicatorInsets.bottom, scrollView.scrollIndicatorInsets.right);
+    
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidScroll:)])
+    {
+        [self.delegate scrollViewDidScroll:scrollView];
+    }
+}
+
+- (void)scrollViewDidZoom:(UIScrollView *)scrollView;
+{
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidZoom:)])
+    {
+        [self.delegate scrollViewDidZoom:scrollView];
+    }
+}
+
+- (void)scrollViewWillBeginDragging:(UIScrollView *)scrollView;
+{
+    if ([self.delegate respondsToSelector:@selector(scrollViewWillBeginDragging:)])
+    {
+        [self.delegate scrollViewWillBeginDragging:scrollView];
+    }
+}
+
+- (void)scrollViewWillEndDragging:(UIScrollView *)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint *)targetContentOffset;
+{
+    if ([self.delegate respondsToSelector:@selector(scrollViewWillEndDragging:withVelocity:targetContentOffset:)])
+    {
+        [self.delegate scrollViewWillEndDragging:scrollView withVelocity:velocity targetContentOffset:targetContentOffset];
+    }
+}
+
+- (void)scrollViewWillBeginDecelerating:(UIScrollView *)scrollView;
+{
+    if ([self.delegate respondsToSelector:@selector(scrollViewWillBeginDecelerating:)])
+    {
+        [self.delegate scrollViewWillBeginDecelerating:scrollView];
+    }
+}
+
+- (void)scrollViewDidEndScrollingAnimation:(UIScrollView *)scrollView;
+{
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidEndScrollingAnimation:)])
+    {
+        [self.delegate scrollViewDidEndScrollingAnimation:scrollView];
+    }
+}
+
+- (nullable UIView *)viewForZoomingInScrollView:(UIScrollView *)scrollView;
+{
+    if ([self.delegate respondsToSelector:@selector(viewForZoomingInScrollView:)])
+    {
+        return [self.delegate viewForZoomingInScrollView:scrollView];
+    }
+    
+    return nil;
+}
+
+- (void)scrollViewWillBeginZooming:(UIScrollView *)scrollView withView:(nullable UIView *)view;
+{
+    if ([self.delegate respondsToSelector:@selector(scrollViewWillBeginZooming:withView:)])
+    {
+        [self.delegate scrollViewWillBeginZooming:scrollView withView:view];
+    }
+}
+
+- (void)scrollViewDidEndZooming:(UIScrollView *)scrollView withView:(nullable UIView *)view atScale:(CGFloat)scale;
+{
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidEndZooming:withView:atScale:)])
+    {
+        [self.delegate scrollViewDidEndZooming:scrollView withView:view atScale:scale];
+    }
+}
+
+- (BOOL)scrollViewShouldScrollToTop:(UIScrollView *)scrollView;
+{
+    if ([self.delegate respondsToSelector:@selector(scrollViewShouldScrollToTop:)])
+    {
+        return [self.delegate scrollViewShouldScrollToTop:scrollView];
+    }
+    
+    return YES;
+}
+
+- (void)scrollViewDidScrollToTop:(UIScrollView *)scrollView;
+{
+    if ([self.delegate respondsToSelector:@selector(scrollViewDidScrollToTop:)])
+    {
+        [self.delegate scrollViewDidScrollToTop:scrollView];
+    }
 }
 
 @end

--- a/BLKFlexibleHeightBar/SafariStyleBehaviorDefiner.h
+++ b/BLKFlexibleHeightBar/SafariStyleBehaviorDefiner.h
@@ -1,0 +1,34 @@
+/*
+ Copyright (c) 2015, Bryan Keller. All rights reserved.
+ Licensed under the MIT license <http://opensource.org/licenses/MIT>
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ IN THE SOFTWARE.
+ */
+
+/*
+ Safari style behavior definer by VragonerDev
+*/
+
+#import "BLKFlexibleHeightBarBehaviorDefiner.h"
+
+@interface SafariStyleBehaviorDefiner : BLKFlexibleHeightBarBehaviorDefiner
+
+/**
+ The non-negative value used for implementing Safari-style bar behavior when scrolling down with velocity.
+ Bigger value means that a bigger velocity is needed to expand the bar to the maximum height. The default value is 0.4.
+ */
+@property (nonatomic) CGFloat velocityThreshold;
+
+@end

--- a/BLKFlexibleHeightBar/SafariStyleBehaviorDefiner.m
+++ b/BLKFlexibleHeightBar/SafariStyleBehaviorDefiner.m
@@ -1,0 +1,109 @@
+/*
+ Copyright (c) 2015, Bryan Keller. All rights reserved.
+ Licensed under the MIT license <http://opensource.org/licenses/MIT>
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all copies or substantial portions
+ of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+ TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ IN THE SOFTWARE.
+ */
+
+#import "SafariStyleBehaviorDefiner.h"
+#import "BLKFlexibleHeightBar.h"
+
+#define kDefaultVelocityThreshold   0.4
+
+@interface SafariStyleBehaviorDefiner ()
+{
+    CGFloat previousScrollPosition;
+}
+@end
+
+@implementation SafariStyleBehaviorDefiner
+
+#pragma mark -
+#pragma mark Init
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self)
+    {
+        self.velocityThreshold = kDefaultVelocityThreshold;
+    }
+    return self;
+}
+
+#pragma mark -
+#pragma mark Scroll view delegate methods
+
+- (void)scrollViewWillBeginDragging:(UIScrollView*)scrollView
+{
+    [super scrollViewWillBeginDragging:scrollView];
+
+    previousScrollPosition = scrollView.contentOffset.y + scrollView.contentInset.top;
+}
+
+- (void)scrollViewDidScroll:(UIScrollView*)scrollView
+{
+    [super scrollViewDidScroll:scrollView];
+    
+    CGFloat scrollPosition = scrollView.contentOffset.y + scrollView.contentInset.top;
+
+    if (!self.isCurrentlySnapping)
+    {
+        CGFloat newProgress = self.flexibleHeightBar.progress;
+        
+        if (scrollPosition < 0.0)
+        {
+            newProgress = 0.0;
+        }
+        else if ((scrollView.contentOffset.y - scrollView.contentInset.bottom) >= scrollView.contentSize.height)
+        {
+            newProgress = 1.0;
+        }
+        else
+        {
+            CGFloat barHeight = self.flexibleHeightBar.maximumBarHeight - self.flexibleHeightBar.minimumBarHeight;
+            CGFloat progressDelta = (scrollPosition - previousScrollPosition) / barHeight;
+
+            if ((progressDelta > 0.0) || (scrollPosition < barHeight))
+            {
+                newProgress += progressDelta;
+            }
+        }
+
+        if (self.flexibleHeightBar.progress != newProgress)
+        {
+            self.flexibleHeightBar.progress = newProgress;
+            [self.flexibleHeightBar setNeedsLayout];
+        }
+    }
+    
+    previousScrollPosition = scrollPosition;
+}
+
+- (void)scrollViewWillEndDragging:(UIScrollView*)scrollView withVelocity:(CGPoint)velocity targetContentOffset:(inout CGPoint*)targetContentOffset
+{
+    [super scrollViewWillEndDragging:scrollView withVelocity:velocity targetContentOffset:targetContentOffset];
+    
+    if (velocity.y < -self.velocityThreshold)
+    {
+        self.flexibleHeightBar.progress = 0.0;
+        
+        [self snapWithScrollView:scrollView];
+    }
+}
+
+@end
+
+#undef kDefaultVelocityThreshold


### PR DESCRIPTION
With proposed delegate property in BLKFlexibleHeightBarBehaviorDefiner anyone can easily create delegate chains. E.g, when a UITableView sets its delegate to an instance of BLKFlexibleHeightBarBehaviorDefiner but also wants another object to act as the UITableViewDelegate you can write something like this:
```
myBar.behaviorDefiner.delegate = anotherObject;
self.tableView.delegate = (id<UITableViewDelegate>)myBar.behaviorDefiner;
```